### PR TITLE
Multiclient tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ results/*
 venv
 
 .idea
+.vscode

--- a/algos.yaml
+++ b/algos.yaml
@@ -48,42 +48,33 @@ float:
       constructor: RediSearch
       base-args: ["FLAT", "@metric", "@connection"]
       run-groups:
-        M-4:
+        BS-2^20:
           arg-groups:
-            - {"M": 4,  "efConstruction": 500}
-          query-args: [[10, 20, 40, 80, 120, 200, 400, 600, 800]]
+            - {"BLOCK_SIZE": 1048576}
         # M-8:
         #   arg-groups:
-        #     - {"M": 8,  "efConstruction": 500}
-        #   query-args: [[10, 20, 40, 80, 120, 200, 400, 600, 800]]
+        #     - {"BLOCK_SIZE": 1048576}
         # M-12:
         #   arg-groups:
-        #     - {"M": 12,  "efConstruction": 500}
-        #   query-args: [[10, 20, 40, 80, 120, 200, 400, 600, 800]]
+        #     - {"BLOCK_SIZE": 1048576}
         # M-16:
         #   arg-groups:
-        #     - {"M": 16,  "efConstruction": 500}
-        #   query-args: [[10, 20, 40, 80, 120, 200, 400, 600, 800]]
+        #     - {"BLOCK_SIZE": 1048576}
         # M-24:
         #   arg-groups:
-        #     - {"M": 24,  "efConstruction": 500}
-        #   query-args: [[10, 20, 40, 80, 120, 200, 400, 600, 800]]
+        #     - {"BLOCK_SIZE": 1048576}
         # M-36:
         #   arg-groups:
-        #     - {"M": 36,  "efConstruction": 500}
-        #   query-args: [[10, 20, 40, 80, 120, 200, 400, 600, 800]]
+        #     - {"BLOCK_SIZE": 1048576}
         # M-48:
         #   arg-groups:
-        #     - {"M": 48,  "efConstruction": 500}
-        #   query-args: [[10, 20, 40, 80, 120, 200, 400, 600, 800]]
+        #     - {"BLOCK_SIZE": 1048576}
         # M-64:
         #   arg-groups:
-        #     - {"M": 64,  "efConstruction": 500}
-        #   query-args: [[10, 20, 40, 80, 120, 200, 400, 600, 800]]
+        #     - {"BLOCK_SIZE": 1048576}
         # M-96:
         #   arg-groups:
-        #     - {"M": 96,  "efConstruction": 500}
-        #   query-args: [[10, 20, 40, 80, 120, 200, 400, 600, 800]]
+        #     - {"BLOCK_SIZE": 1048576}
     sptag:
       docker-tag: ann-benchmarks-sptag
       module: ann_benchmarks.algorithms.sptag

--- a/algos.yaml
+++ b/algos.yaml
@@ -1,10 +1,52 @@
 float:
   any:
-    redisearch:
+    redisearch-hnsw:
       docker-tag: ann-benchmarks-redisearch
       module: ann_benchmarks.algorithms.redisearch
       constructor: RediSearch
-      base-args: ["@metric"]
+      base-args: ["HNSW", "@metric", "@connection"]
+      run-groups:
+        M-4:
+          arg-groups:
+            - {"M": 4,  "efConstruction": 500}
+          query-args: [[10, 20, 40, 80, 120, 200, 400, 600, 800]]
+        # M-8:
+        #   arg-groups:
+        #     - {"M": 8,  "efConstruction": 500}
+        #   query-args: [[10, 20, 40, 80, 120, 200, 400, 600, 800]]
+        # M-12:
+        #   arg-groups:
+        #     - {"M": 12,  "efConstruction": 500}
+        #   query-args: [[10, 20, 40, 80, 120, 200, 400, 600, 800]]
+        # M-16:
+        #   arg-groups:
+        #     - {"M": 16,  "efConstruction": 500}
+        #   query-args: [[10, 20, 40, 80, 120, 200, 400, 600, 800]]
+        # M-24:
+        #   arg-groups:
+        #     - {"M": 24,  "efConstruction": 500}
+        #   query-args: [[10, 20, 40, 80, 120, 200, 400, 600, 800]]
+        # M-36:
+        #   arg-groups:
+        #     - {"M": 36,  "efConstruction": 500}
+        #   query-args: [[10, 20, 40, 80, 120, 200, 400, 600, 800]]
+        # M-48:
+        #   arg-groups:
+        #     - {"M": 48,  "efConstruction": 500}
+        #   query-args: [[10, 20, 40, 80, 120, 200, 400, 600, 800]]
+        # M-64:
+        #   arg-groups:
+        #     - {"M": 64,  "efConstruction": 500}
+        #   query-args: [[10, 20, 40, 80, 120, 200, 400, 600, 800]]
+        # M-96:
+        #   arg-groups:
+        #     - {"M": 96,  "efConstruction": 500}
+        #   query-args: [[10, 20, 40, 80, 120, 200, 400, 600, 800]]
+    redisearch-flat:
+      docker-tag: ann-benchmarks-redisearch
+      module: ann_benchmarks.algorithms.redisearch
+      constructor: RediSearch
+      base-args: ["FLAT", "@metric", "@connection"]
       run-groups:
         M-4:
           arg-groups:

--- a/ann_benchmarks/algorithms/definitions.py
+++ b/ann_benchmarks/algorithms/definitions.py
@@ -97,7 +97,7 @@ def get_unique_algorithms(definition_file):
 
 
 def get_definitions(definition_file, dimension, point_type="float",
-                    distance_metric="euclidean", count=10):
+                    distance_metric="euclidean", count=10, conn_params=dict()):
     definitions = _get_definitions(definition_file)
 
     algorithm_definitions = {}
@@ -157,7 +157,8 @@ def get_definitions(definition_file, dimension, point_type="float",
                 vs = {
                     "@count": count,
                     "@metric": distance_metric,
-                    "@dimension": dimension
+                    "@dimension": dimension,
+                    "@connection": conn_params
                 }
                 aargs = [_substitute_variables(arg, vs) for arg in aargs]
                 definitions.append(Definition(

--- a/ann_benchmarks/algorithms/redisearch.py
+++ b/ann_benchmarks/algorithms/redisearch.py
@@ -1,40 +1,39 @@
 from __future__ import absolute_import
-import os
-import base64
 from redis import Redis
-from redisearch import Client, Query 
-import numpy as np
+from redisearch import Client, Query
 from ann_benchmarks.constants import INDEX_DIR
 from ann_benchmarks.algorithms.base import BaseANN
 
 
 class RediSearch(BaseANN):
-    def __init__(self, metric, method_param):
+    def __init__(self, algo, metric, conn_params, method_param):
         self.metric = {'angular': 'cosine', 'euclidean': 'l2'}[metric]
         self.method_param = method_param
+        self.algo = algo
         # print(self.method_param,save_index,query_param)
         # self.ef=query_param['ef']
-        self.name = 'redisearch (%s)' % (self.method_param)
+        self.name = 'redisearch-%s (%s)' % (self.algo, self.method_param)
         self.index_name = "ann_benchmark"
-        self.client = Client(self.index_name, conn = Redis(decode_responses=False))
+        conn = Redis(host=conn_params["host"], port=conn_params["port"],
+                     password=conn_params["auth"], username=conn_params["user"],
+                     decode_responses=False)
+        self.client = Client(self.index_name, conn = conn)
 
-    def fit(self, X):
-        # Only l2 is supported currently
-        self.client.redis.execute_command('FT.CREATE', self.index_name, 'SCHEMA', 'vector',  'VECTOR', 'FLOAT32', len(X[0]), 'L2', 'HNSW', 'INITIAL_CAP', len(X), 'M', self.method_param['M'] , 'EF', self.method_param["efConstruction"])
+    def fit(self, X, offset=0, cap=None):
+        try:
+            self.client.redis.execute_command('FT.CREATE', self.index_name, 'SCHEMA', 'vector', 'VECTOR', self.algo, '12', 'TYPE', 'FLOAT32', 'DIM', len(X[0]), 'DISTANCE_METRIC', self.metric, 'INITIAL_CAP', cap if cap else len(X), 'M', self.method_param['M'] , 'EF_CONSTRUCTION', self.method_param["efConstruction"])
+        except Exception:
+            pass
+
         for i, x in enumerate(X):
-            self.client.redis.execute_command('HSET', f'ann_{i}', 'vector', x.tobytes())
-
+            self.client.redis.execute_command('HSET', f'ann_{i+offset}', 'vector', x.tobytes())
 
     def set_query_arguments(self, ef):
         self.ef = ef
 
     def query(self, v, k):
-        base64_vector = base64.b64encode(v).decode('ascii')
-        base64_vector_escaped = base64_vector.translate(str.maketrans({"=":  r"\=",
-                                              "/":  r"\/",
-                                              "+":  r"\+"}))
-        q = Query('@vector:[' + base64_vector_escaped + ' TOPK ' +str(k)+'] => {$BASE64:TRUE; $efruntime:' + str(self.ef) + '}').sort_by('vector', asc=True).no_content()
-        return [int(doc.id.replace('ann_','')) for doc in self.client.search(q).docs]
+        q = Query('*=>[TOP_K ' + str(k) + ' @vector $BLOB EF_RUNTIME ' + str(self.ef) + ']').sort_by('__vector_score', asc=True).no_content()
+        return [int(doc.id.replace('ann_','')) for doc in self.client.search(q, query_params = {'BLOB': v.tobytes()}).docs]
 
     def freeIndex(self):
         self.client.redis.execute_command("FLUSHALL")

--- a/ann_benchmarks/algorithms/redisearch.py
+++ b/ann_benchmarks/algorithms/redisearch.py
@@ -10,8 +10,6 @@ class RediSearch(BaseANN):
         self.metric = {'angular': 'cosine', 'euclidean': 'l2'}[metric]
         self.method_param = method_param
         self.algo = algo
-        # print(self.method_param,save_index,query_param)
-        # self.ef=query_param['ef']
         self.name = 'redisearch-%s (%s)' % (self.algo, self.method_param)
         self.index_name = "ann_benchmark"
         conn = Redis(host=conn_params["host"], port=conn_params["port"],
@@ -19,20 +17,29 @@ class RediSearch(BaseANN):
                      decode_responses=False)
         self.client = Client(self.index_name, conn = conn)
 
-    def fit(self, X, offset=0, cap=None):
+    def fit(self, X, offset=0, limit=None):
+        limit = limit if limit else len(X)
+        # print('inserting %d out of %d vectors' % (limit-offset, len(X)))
         try:
-            self.client.redis.execute_command('FT.CREATE', self.index_name, 'SCHEMA', 'vector', 'VECTOR', self.algo, '12', 'TYPE', 'FLOAT32', 'DIM', len(X[0]), 'DISTANCE_METRIC', self.metric, 'INITIAL_CAP', cap if cap else len(X), 'M', self.method_param['M'] , 'EF_CONSTRUCTION', self.method_param["efConstruction"])
-        except Exception:
-            pass
+            if self.algo == "HNSW":
+                self.client.redis.execute_command('FT.CREATE', self.index_name, 'SCHEMA', 'vector', 'VECTOR', self.algo, '12', 'TYPE', 'FLOAT32', 'DIM', len(X[0]), 'DISTANCE_METRIC', self.metric, 'INITIAL_CAP', len(X), 'M', self.method_param['M'] , 'EF_CONSTRUCTION', self.method_param["efConstruction"])
+            elif self.algo == "FLAT":
+                self.client.redis.execute_command('FT.CREATE', self.index_name, 'SCHEMA', 'vector', 'VECTOR', self.algo, '10', 'TYPE', 'FLOAT32', 'DIM', len(X[0]), 'DISTANCE_METRIC', self.metric, 'INITIAL_CAP', len(X), 'BLOCK_SIZE', self.method_param['BLOCK_SIZE'])
 
-        for i, x in enumerate(X):
-            self.client.redis.execute_command('HSET', f'ann_{i+offset}', 'vector', x.tobytes())
+        except Exception as e:
+            if 'Index already exists' not in str(e):
+                raise
+
+        for i in range(offset, limit):
+            self.client.redis.execute_command('HSET', f'ann_{i}', 'vector', X[i].tobytes())
 
     def set_query_arguments(self, ef):
         self.ef = ef
 
     def query(self, v, k):
-        q = Query('*=>[TOP_K ' + str(k) + ' @vector $BLOB EF_RUNTIME ' + str(self.ef) + ']').sort_by('__vector_score', asc=True).no_content()
+        vq = '*=>[TOP_K ' + str(k) + ' @vector $BLOB'
+        vq += ((' EF_RUNTIME ' + str(self.ef)) if self.algo == 'HNSW' else '')
+        q = Query(vq + ']').sort_by('__vector_score', asc=True).paging(0, k).no_content()
         return [int(doc.id.replace('ann_','')) for doc in self.client.search(q, query_params = {'BLOB': v.tobytes()}).docs]
 
     def freeIndex(self):

--- a/ann_benchmarks/algorithms/redisearch.py
+++ b/ann_benchmarks/algorithms/redisearch.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 from redis import Redis
-from redisearch import Client, Query
+from redis.cluster import RedisCluster
 from ann_benchmarks.constants import INDEX_DIR
 from ann_benchmarks.algorithms.base import BaseANN
 
@@ -12,36 +12,36 @@ class RediSearch(BaseANN):
         self.algo = algo
         self.name = 'redisearch-%s (%s)' % (self.algo, self.method_param)
         self.index_name = "ann_benchmark"
-        conn = Redis(host=conn_params["host"], port=conn_params["port"],
-                     password=conn_params["auth"], username=conn_params["user"],
-                     decode_responses=False)
-        self.client = Client(self.index_name, conn = conn)
+        
+        redis = RedisCluster if conn_params['cluster'] else Redis
+        self.redis = redis(host=conn_params["host"], port=conn_params["port"],
+                           password=conn_params["auth"], username=conn_params["user"],
+                           decode_responses=False)
 
     def fit(self, X, offset=0, limit=None):
         limit = limit if limit else len(X)
         # print('inserting %d out of %d vectors' % (limit-offset, len(X)))
         try:
             if self.algo == "HNSW":
-                self.client.redis.execute_command('FT.CREATE', self.index_name, 'SCHEMA', 'vector', 'VECTOR', self.algo, '12', 'TYPE', 'FLOAT32', 'DIM', len(X[0]), 'DISTANCE_METRIC', self.metric, 'INITIAL_CAP', len(X), 'M', self.method_param['M'] , 'EF_CONSTRUCTION', self.method_param["efConstruction"])
+                self.redis.execute_command('FT.CREATE', self.index_name, 'SCHEMA', 'vector', 'VECTOR', self.algo, '12', 'TYPE', 'FLOAT32', 'DIM', len(X[0]), 'DISTANCE_METRIC', self.metric, 'INITIAL_CAP', len(X), 'M', self.method_param['M'] , 'EF_CONSTRUCTION', self.method_param["efConstruction"], target_nodes='random')
             elif self.algo == "FLAT":
-                self.client.redis.execute_command('FT.CREATE', self.index_name, 'SCHEMA', 'vector', 'VECTOR', self.algo, '10', 'TYPE', 'FLOAT32', 'DIM', len(X[0]), 'DISTANCE_METRIC', self.metric, 'INITIAL_CAP', len(X), 'BLOCK_SIZE', self.method_param['BLOCK_SIZE'])
-
+                self.redis.execute_command('FT.CREATE', self.index_name, 'SCHEMA', 'vector', 'VECTOR', self.algo, '10', 'TYPE', 'FLOAT32', 'DIM', len(X[0]), 'DISTANCE_METRIC', self.metric, 'INITIAL_CAP', len(X), 'BLOCK_SIZE', self.method_param['BLOCK_SIZE'], target_nodes='random')
         except Exception as e:
             if 'Index already exists' not in str(e):
                 raise
 
         for i in range(offset, limit):
-            self.client.redis.execute_command('HSET', f'ann_{i}', 'vector', X[i].tobytes())
+            self.redis.execute_command('HSET', f'ann_{i}', 'vector', X[i].tobytes())
 
     def set_query_arguments(self, ef):
         self.ef = ef
 
     def query(self, v, k):
-        vq = '*=>[TOP_K ' + str(k) + ' @vector $BLOB'
-        vq += ((' EF_RUNTIME ' + str(self.ef)) if self.algo == 'HNSW' else '')
-        q = Query(vq + ']').sort_by('__vector_score', asc=True).paging(0, k).no_content()
-        return [int(doc.id.replace('ann_','')) for doc in self.client.search(q, query_params = {'BLOB': v.tobytes()}).docs]
+        qparams = (' EF_RUNTIME ' + str(self.ef)) if self.algo == 'HNSW' else ''
+        vq = '*=>[TOP_K ' + str(k) + ' @vector $BLOB' + qparams + ']'
+        q = ['FT.SEARCH', self.index_name, vq, 'NOCONTENT', 'SORTBY', '__vector_score', 'LIMIT', '0', str(k), 'PARAMS', '2', 'BLOB', v.tobytes()]
+        return [int(doc.replace(b'ann_',b'')) for doc in self.redis.execute_command(*q, target_nodes='random')[1:]]
 
     def freeIndex(self):
-        self.client.redis.execute_command("FLUSHALL")
+        self.redis.execute_command("FLUSHALL")
 

--- a/ann_benchmarks/algorithms/redisearch.py
+++ b/ann_benchmarks/algorithms/redisearch.py
@@ -20,8 +20,8 @@ class RediSearch(BaseANN):
 
     def fit(self, X, offset=0, limit=None):
         limit = limit if limit else len(X)
-        # print('inserting %d out of %d vectors' % (limit-offset, len(X)))
         try:
+            # https://oss.redis.com/redisearch/master/Commands/#ftcreate
             if self.algo == "HNSW":
                 self.redis.execute_command('FT.CREATE', self.index_name, 'SCHEMA', 'vector', 'VECTOR', self.algo, '12', 'TYPE', 'FLOAT32', 'DIM', len(X[0]), 'DISTANCE_METRIC', self.metric, 'INITIAL_CAP', len(X), 'M', self.method_param['M'] , 'EF_CONSTRUCTION', self.method_param["efConstruction"], target_nodes='random')
             elif self.algo == "FLAT":
@@ -37,8 +37,9 @@ class RediSearch(BaseANN):
         self.ef = ef
 
     def query(self, v, k):
-        qparams = (' EF_RUNTIME ' + str(self.ef)) if self.algo == 'HNSW' else ''
-        vq = '*=>[TOP_K ' + str(k) + ' @vector $BLOB' + qparams + ']'
+        # https://oss.redis.com/redisearch/master/Commands/#ftsearch
+        qparams = f' EF_RUNTIME {self.ef}' if self.algo == 'HNSW' else ''
+        vq = f'*=>[TOP_K {k} @vector $BLOB {qparams}]'
         q = ['FT.SEARCH', self.index_name, vq, 'NOCONTENT', 'SORTBY', '__vector_score', 'LIMIT', '0', str(k), 'PARAMS', '2', 'BLOB', v.tobytes()]
         return [int(doc.replace(b'ann_',b'')) for doc in self.redis.execute_command(*q, target_nodes='random')[1:]]
 

--- a/ann_benchmarks/main.py
+++ b/ann_benchmarks/main.py
@@ -147,7 +147,7 @@ def main():
         default=6379)
     parser.add_argument(
         '--auth', '-a',
-        metavar='NAME',
+        metavar='PASSWORD',
         help='password for connection',
         default=None)
     parser.add_argument(
@@ -157,13 +157,15 @@ def main():
         default=None)
     parser.add_argument(
         '--total-clients',
+        metavar='NUM',
         type=positive_int,
-        help='the port "host" is listening on',
+        help='total number of clients running in parallel',
         default=1)
     parser.add_argument(
         '--client-id',
+        metavar='NUM',
         type=positive_int,
-        help='the port "host" is listening on',
+        help='specific client id (among the total client)',
         default=1)
 
     args = parser.parse_args()

--- a/ann_benchmarks/main.py
+++ b/ann_benchmarks/main.py
@@ -132,6 +132,10 @@ def main():
         action='store_true',
         help='querying index only, not building it (should be built first)')
     parser.add_argument(
+        '--cluster',
+        action='store_true',
+        help='working with a cluster')
+    parser.add_argument(
         '--host',
         metavar='NAME',
         help='host name or IP',
@@ -175,7 +179,7 @@ def main():
     if (args.build_only or args.test_only) and not args.local:
         raise Exception('Can\'t run build or test only on docker')
 
-    conn_params = {'host': args.host, 'port': args.port, 'auth': args.auth, 'user': args.user}
+    conn_params = {'host': args.host, 'port': args.port, 'auth': args.auth, 'user': args.user, 'cluster': args.cluster}
 
     if args.total_clients < args.client_id:
         raise Exception('must satisfy 1 <= client_id <= total_clients')

--- a/ann_benchmarks/main.py
+++ b/ann_benchmarks/main.py
@@ -175,8 +175,6 @@ def main():
     if (args.build_only or args.test_only) and not args.local:
         raise Exception('Can\'t run build or test only on docker')
 
-    if args.user and not args.auth:
-        raise Exception('username specified without password (Auth)')
     conn_params = {'host': args.host, 'port': args.port, 'auth': args.auth, 'user': args.user}
 
     if args.total_clients < args.client_id:

--- a/ann_benchmarks/main.py
+++ b/ann_benchmarks/main.py
@@ -37,7 +37,8 @@ def run_worker(cpu, args, queue):
     while not queue.empty():
         definition = queue.get()
         if args.local:
-            run(definition, args.dataset, args.count, args.runs, args.batch)
+            run(definition, args.dataset, args.count, args.runs, args.batch,
+                args.build_only, args.test_only, args.total_clients, args.client_id)
         else:
             memory_margin = 500e6  # reserve some extra memory for misc stuff
             mem_limit = int((psutil.virtual_memory().available - memory_margin) / args.parallelism)
@@ -122,6 +123,44 @@ def main():
         type=positive_int,
         help='Number of Docker containers in parallel',
         default=1)
+    parser.add_argument(
+        '--build-only',
+        action='store_true',
+        help='building index only, not testing with queries')
+    parser.add_argument(
+        '--test-only',
+        action='store_true',
+        help='querying index only, not building it (should be built first)')
+    parser.add_argument(
+        '--host',
+        metavar='NAME',
+        help='host name or IP',
+        default="localhost")
+    parser.add_argument(
+        '--port',
+        type=positive_int,
+        help='the port "host" is listening on',
+        default=6379)
+    parser.add_argument(
+        '--auth', '-a',
+        metavar='NAME',
+        help='password for connection',
+        default=None)
+    parser.add_argument(
+        '--user',
+        metavar='NAME',
+        help='user name for connection',
+        default=None)
+    parser.add_argument(
+        '--total-clients',
+        type=positive_int,
+        help='the port "host" is listening on',
+        default=1)
+    parser.add_argument(
+        '--client-id',
+        type=positive_int,
+        help='the port "host" is listening on',
+        default=1)
 
     args = parser.parse_args()
     if args.timeout == -1:
@@ -130,6 +169,18 @@ def main():
     if args.list_algorithms:
         list_algorithms(args.definitions)
         sys.exit(0)
+    
+    if args.build_only and args.test_only:
+        raise Exception('Nothing to run (build only and test only was specified)')
+    if (args.build_only or args.test_only) and not args.local:
+        raise Exception('Can\'t run build or test only on docker')
+
+    if args.user and not args.auth:
+        raise Exception('username specified without password (Auth)')
+    conn_params = {'host': args.host, 'port': args.port, 'auth': args.auth, 'user': args.user}
+
+    if args.total_clients < args.client_id:
+        raise Exception('must satisfy 1 <= client_id <= total_clients')
 
     logging.config.fileConfig("logging.conf")
     logger = logging.getLogger("annb")
@@ -143,7 +194,7 @@ def main():
     point_type = dataset.attrs.get('point_type', 'float')
     distance = dataset.attrs['distance']
     definitions = get_definitions(
-        args.definitions, dimension, point_type, distance, args.count)
+        args.definitions, dimension, point_type, distance, args.count, conn_params)
 
     # Filter out, from the loaded definitions, all those query argument groups
     # that correspond to experiments that have already been run. (This might

--- a/ann_benchmarks/results.py
+++ b/ann_benchmarks/results.py
@@ -8,7 +8,7 @@ import traceback
 
 
 def get_result_filename(dataset=None, count=None, definition=None,
-                        query_arguments=None, batch_mode=False):
+                        query_arguments=None, batch_mode=False, id=0):
     d = ['results']
     if dataset:
         d.append(dataset)
@@ -16,16 +16,20 @@ def get_result_filename(dataset=None, count=None, definition=None,
         d.append(str(count))
     if definition:
         d.append(definition.algorithm + ('-batch' if batch_mode else ''))
-        data = definition.arguments + query_arguments
-        d.append(re.sub(r'\W+', '_', json.dumps(data, sort_keys=True))
-                 .strip('_') + ".hdf5")
+        if 'redisearch' in definition.algorithm:
+            prefix = re.sub(r'\W+', '_', json.dumps(query_arguments, sort_keys=True)).strip('_')
+            d.append(prefix + f'_client_{id}.hdf5')
+        else:
+            data = definition.arguments + query_arguments
+            d.append(re.sub(r'\W+', '_', json.dumps(data, sort_keys=True))
+                     .strip('_') + ".hdf5")
     return os.path.join(*d)
 
 
 def store_results(dataset, count, definition, query_arguments, attrs, results,
-                  batch):
+                  batch, id=0):
     fn = get_result_filename(
-        dataset, count, definition, query_arguments, batch)
+        dataset, count, definition, query_arguments, batch, id)
     head, tail = os.path.split(fn)
     if not os.path.isdir(head):
         os.makedirs(head)

--- a/ann_benchmarks/runner.py
+++ b/ann_benchmarks/runner.py
@@ -111,7 +111,6 @@ function""" % (definition.module, definition.constructor, definition.arguments)
     print('got a train set of size (%d * %d)' % (X_train.shape[0], dimension))
 
     X_train, X_test = dataset_transform(D)
-    # X_train = X_train[:5000]
 
     try:
         prepared_queries = False

--- a/ann_benchmarks/runner.py
+++ b/ann_benchmarks/runner.py
@@ -5,6 +5,8 @@ import os
 import threading
 import time
 import traceback
+import h5py
+import inspect
 
 import colors
 import docker
@@ -15,7 +17,7 @@ from ann_benchmarks.algorithms.definitions import (Definition,
                                                    instantiate_algorithm)
 from ann_benchmarks.datasets import get_dataset, DATASETS
 from ann_benchmarks.distance import metrics, dataset_transform
-from ann_benchmarks.results import store_results
+from ann_benchmarks.results import store_results, get_result_filename
 
 
 def run_individual_query(algo, X_train, X_test, distance, count, run_count,
@@ -95,7 +97,7 @@ def run_individual_query(algo, X_train, X_test, distance, count, run_count,
     return (attrs, results)
 
 
-def run(definition, dataset, count, run_count, batch):
+def run(definition, dataset, count, run_count, batch, build_only, test_only, num_clients, id):
     algo = instantiate_algorithm(definition)
     assert not definition.query_argument_groups \
            or hasattr(algo, "set_query_arguments"), """\
@@ -108,22 +110,51 @@ function""" % (definition.module, definition.constructor, definition.arguments)
     X_test = numpy.array(D['test'])
     distance = D.attrs['distance']
     print('got a train set of size (%d * %d)' % (X_train.shape[0], dimension))
-    print('got %d queries' % len(X_test))
 
     X_train, X_test = dataset_transform(D)
+    # X_train = X_train[:5000]
 
     try:
         prepared_queries = False
         if hasattr(algo, "supports_prepared_queries"):
             prepared_queries = algo.supports_prepared_queries()
 
-        t0 = time.time()
-        memory_usage_before = algo.get_memory_usage()
-        algo.fit(X_train)
-        build_time = time.time() - t0
-        index_size = algo.get_memory_usage() - memory_usage_before
-        print('Built index in', build_time)
-        print('Index size: ', index_size)
+        if not test_only:
+            per_client = len(X_train) // num_clients
+            offset = per_client * (id - 1)
+            if num_clients == id:
+                fit_args = [X_train[offset:]]
+            else:
+                fit_args = [X_train[offset:(offset + per_client)]]
+            print('inserting %d out of %d vectors' % (len(fit_args[0]), len(X_train)))
+            if "offset" and "cap" in inspect.getfullargspec(algo.fit)[0]:
+                fit_args.append(offset)
+                fit_args.append(len(X_train))
+            
+            t0 = time.time()
+            memory_usage_before = algo.get_memory_usage()
+            algo.fit(*fit_args)
+            build_time = time.time() - t0
+            index_size = algo.get_memory_usage() - memory_usage_before
+            print('Built index in', build_time)
+            print('Index size: ', index_size)
+        #     if build_only:
+        #         fn = get_result_filename(dataset, count)
+        #         fn = os.path.join(fn, definition.algorithm)
+        #         if not os.path.isdir(fn):
+        #             os.makedirs(fn)
+        #         fn = os.path.join(fn, f'build_stats_{id}.hdf5')
+        #         f = h5py.File(fn, 'w')
+        #         f.attrs["build_time"] = build_time
+        #         f.attrs["index_size"] = index_size
+        #         f.close()
+        else:
+            fn = get_result_filename(dataset, count)
+            fn = os.path.join(fn, 'build_stats.hdf5')
+            f = h5py.File(fn, 'r')
+            build_time = f.attrs["build_time"]
+            index_size = f.attrs["index_size"]
+            f.close()
 
         query_argument_groups = definition.query_argument_groups
         # Make sure that algorithms with no query argument groups still get run
@@ -131,19 +162,21 @@ function""" % (definition.module, definition.constructor, definition.arguments)
         if not query_argument_groups:
             query_argument_groups = [[]]
 
-        for pos, query_arguments in enumerate(query_argument_groups, 1):
-            print("Running query argument group %d of %d..." %
-                  (pos, len(query_argument_groups)))
-            if query_arguments:
-                algo.set_query_arguments(*query_arguments)
-            descriptor, results = run_individual_query(
-                algo, X_train, X_test, distance, count, run_count, batch)
-            descriptor["build_time"] = build_time
-            descriptor["index_size"] = index_size
-            descriptor["algo"] = definition.algorithm
-            descriptor["dataset"] = dataset
-            store_results(dataset, count, definition,
-                          query_arguments, descriptor, results, batch)
+        if not build_only:
+            print('got %d queries' % len(X_test))
+            for pos, query_arguments in enumerate(query_argument_groups, 1):
+                print("Running query argument group %d of %d..." %
+                      (pos, len(query_argument_groups)))
+                if query_arguments:
+                    algo.set_query_arguments(*query_arguments)
+                descriptor, results = run_individual_query(
+                    algo, X_train, X_test, distance, count, run_count, batch)
+                descriptor["build_time"] = build_time
+                descriptor["index_size"] = index_size
+                descriptor["algo"] = definition.algorithm
+                descriptor["dataset"] = dataset
+                store_results(dataset, count, definition, query_arguments,
+                              descriptor, results, batch, id)
     finally:
         algo.done()
 
@@ -186,6 +219,14 @@ def run_from_cmdline():
         help='If flag included, algorithms will be run in batch mode, rather than "individual query" mode.',
         action='store_true')
     parser.add_argument(
+        '--build-only',
+        action='store_true',
+        help='building index only, not testing with queries')
+    parser.add_argument(
+        '--test-only',
+        action='store_true',
+        help='querying index only, not building it (should be built first)')
+    parser.add_argument(
         'build',
         help='JSON of arguments to pass to the constructor. E.g. ["angular", 100]'
         )
@@ -208,7 +249,7 @@ def run_from_cmdline():
         query_argument_groups=query_args,
         disabled=False
     )
-    run(definition, args.dataset, args.count, args.runs, args.batch)
+    run(definition, args.dataset, args.count, args.runs, args.batch, args.build_only, args.test_only, 1, 1)
 
 
 def run_docker(definition, dataset, count, runs, timeout, batch, cpu_limit,

--- a/multirun.py
+++ b/multirun.py
@@ -43,12 +43,14 @@ if __name__ == "__main__":
     parser.add_argument(
         '--build-clients',
         type=int,
-        help='the port "host" is listening on',
+        metavar='NUM',
+        help='total number of clients running in parallel to build the index (could be 0)',
         default=1)
     parser.add_argument(
         '--test-clients',
         type=int,
-        help='the port "host" is listening on',
+        metavar='NUM',
+        help='total number of clients running in parallel to test the index (could be 0)',
         default=1)
     parser.add_argument(
         '--force',

--- a/multirun.py
+++ b/multirun.py
@@ -1,0 +1,99 @@
+from os import system, path, makedirs
+from multiprocessing import Process
+import argparse
+import time
+from redis import Redis
+import h5py
+from ann_benchmarks.main import positive_int
+from ann_benchmarks.results import get_result_filename
+# from ann_benchmarks.datasets import DATASETS
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument(
+        '--dataset',
+        metavar='NAME',
+        help='the dataset to load training points from',
+        default='glove-100-angular')
+    parser.add_argument(
+        "-k", "--count",
+        default=10,
+        type=positive_int,
+        help="the number of near neighbours to search for")
+    parser.add_argument(
+        '--host',
+        help='host name or IP',
+        default=None)
+    parser.add_argument(
+        '--port',
+        type=positive_int,
+        help='the port "host" is listening on',
+        default=None)
+    parser.add_argument(
+        '--auth', '-a',
+        metavar='PASS',
+        help='password for connection',
+        default=None)
+    parser.add_argument(
+        '--user',
+        metavar='NAME',
+        help='user name for connection',
+        default=None)
+    parser.add_argument(
+        '--build-clients',
+        type=positive_int,
+        help='the port "host" is listening on',
+        default=1)
+    parser.add_argument(
+        '--test-clients',
+        type=positive_int,
+        help='the port "host" is listening on',
+        default=1)
+    parser.add_argument(
+        '--force',
+        help='re-run algorithms even if their results already exist',
+        action='store_true')
+    parser.add_argument(
+        '--algorithm',
+        metavar='ALGO',
+        help='run redisearch with this algorithm',
+        default="hnsw")
+
+    args = parser.parse_args()
+
+    base = 'python run.py --local --algorithm redisearch-' + args.algorithm.lower() + ' --total-clients ' + str(args.build_clients) +\
+           ' -k ' + str(args.count) + ' --dataset ' + args.dataset
+
+    if args.user:   base += ' --user ' + str(args.user)
+    if args.auth:   base += ' --auth ' + str(args.auth)
+    if args.host:   base += ' --host ' + str(args.host)
+    if args.port:   base += ' --port ' + str(args.port)
+    if args.force:  base += ' --force'
+
+    base_build = base + ' --build-only --total-clients ' + str(args.build_clients)
+    base_test = base + ' --test-only --runs 1 --total-clients ' + str(args.test_clients)
+
+    clients = [Process(target=system, args=(base_build + ' --client-id ' + str(i),)) for i in range(1, args.build_clients + 1)]
+
+    t0 = time.time()
+    for client in clients: client.start()
+    for client in clients: client.join()
+    total_time = time.time() - t0
+    print(f'total build time: {total_time}\n\n')
+    
+    fn = get_result_filename(args.dataset, args.count)
+    if not path.isdir(fn):
+        makedirs(fn)
+    fn = path.join(fn, 'build_stats.hdf5')
+    f = h5py.File(fn, 'w')
+    f.attrs["build_time"] = total_time
+    f.attrs["index_size"] = 1000 # demo - add client to get data usage
+    f.close()
+
+    queriers = [Process(target=system, args=(base_test + ' --client-id ' + str(i),)) for i in range(1, args.test_clients + 1)]
+    t0 = time.time()
+    for querier in queriers: querier.start()
+    for querier in queriers: querier.join()
+    query_time = time.time() - t0
+    print(f'total test time: {query_time}')


### PR DESCRIPTION
now supports:
`--build-only` flag for skipping test phase
`--test-only` flag for skipping build phase
`--host HOST` - default "localhost"
`--port PORT` - default 6379
`--auth|-a PASS`,  `--user NAME` for redis authorization 
`--total-clients NUM` for telling the clients how many there are (for splitting load work)
`--client-id NUM` each client id. 1 <= id <= total-clients.

also, updated redisearch API, added FLAT algorithm with besides the default HNSW.

`multirun.py` demonstrates the use of the new options. I can refine it if we intend to use it.
run `python multirun.py --build-clients 5 --test-clients 2` for example.