### PR TITLE
Fixed redisearch query() on non hybrid runs

### DIFF
--- a/ann_benchmarks/algorithms/redisearch.py
+++ b/ann_benchmarks/algorithms/redisearch.py
@@ -13,6 +13,7 @@ class RediSearch(BaseANN):
         self.algo = algo
         self.name = 'redisearch-%s (%s)' % (self.algo, self.method_param)
         self.index_name = "ann_benchmark"
+        self.text = None
         
         redis = RedisCluster if conn_params['cluster'] else Redis
         host = conn_params["host"] if conn_params["host"] else 'localhost'


### PR DESCRIPTION
Fixes the following error
`AttributeError: 'RediSearch' object has no attribute 'text'`
 ( traceback sample of it ) :
```
Process Process-1:
Traceback (most recent call last):
  File "/usr/lib/python3.6/multiprocessing/process.py", line 258, in _bootstrap
    self.run()
  File "/usr/lib/python3.6/multiprocessing/process.py", line 93, in run
    self._target(*self._args, **self._kwargs)
  File "/home/fco/.local/lib/python3.6/site-packages/redisbench_admin/run/ann/pkg/ann_benchmarks/main.py", line 41, in run_worker
    args.build_only, args.test_only, args.total_clients, args.client_id)
  File "/home/fco/.local/lib/python3.6/site-packages/redisbench_admin/run/ann/pkg/ann_benchmarks/runner.py", line 169, in run
    algo, X_train, X_test, distance, count, run_count, batch)
  File "/home/fco/.local/lib/python3.6/site-packages/redisbench_admin/run/ann/pkg/ann_benchmarks/runner.py", line 75, in run_individual_query
    results = [single_query(x) for x in X_test]
  File "/home/fco/.local/lib/python3.6/site-packages/redisbench_admin/run/ann/pkg/ann_benchmarks/runner.py", line 75, in <listcomp>
    results = [single_query(x) for x in X_test]
  File "/home/fco/.local/lib/python3.6/site-packages/redisbench_admin/run/ann/pkg/ann_benchmarks/runner.py", line 44, in single_query
    candidates = algo.query(v, count)
  File "/home/fco/.local/lib/python3.6/site-packages/redisbench_admin/run/ann/pkg/ann_benchmarks/algorithms/redisearch.py", line 73, in query
    if self.text:
AttributeError: 'RediSearch' object has no attribute 'text'
```