### PR TITLE
In multirun change to the proper workdir asap

### DIFF
--- a/multirun.py
+++ b/multirun.py
@@ -135,6 +135,13 @@ if __name__ == "__main__":
         help='working with a cluster')
 
     args = parser.parse_args()
+
+    # we should change to the proper workdir as soon we parse the args
+    # given some functions bellow require on relative path to the project
+    workdir = pathlib.Path(__file__).parent.absolute()
+    print("Changing the workdir to {}".format(workdir))
+    os.chdir(workdir)
+
     isredis = True if 'redisearch' in args.algorithm else False
 
     if args.host is None:
@@ -163,9 +170,6 @@ if __name__ == "__main__":
 
     base_build = base + ' --build-only --total-clients ' + args.build_clients
     base_test = base + ' --test-only --runs {} --total-clients {}'.format(args.runs, args.test_clients)
-    workdir = pathlib.Path(__file__).parent.absolute()
-    print("Changing the workdir to {}".format(workdir))
-    os.chdir(workdir)
     outputsdir = "{}/{}".format(workdir, get_result_filename(args.dataset, args.count))
     outputsdir = os.path.join(outputsdir, args.algorithm)
     if not os.path.isdir(outputsdir):


### PR DESCRIPTION
Solves:
```
022-03-24 22:03:15,055 INFO [chan 0] Opened sftp connection (server version 3)
Traceback (most recent call last):
File "/usr/local/lib/python3.6/dist-packages/redisbench_admin/run/ann/pkg/multirun.py", line 153, in <module>
run_groups = get_run_groups('algos.yaml', args.algorithm)
File "/usr/local/lib/python3.6/dist-packages/redisbench_admin/run/ann/pkg/ann_benchmarks/algorithms/definitions.py", line 100, in get_run_groups
definitions = _get_definitions(definition_file)
File "/usr/local/lib/python3.6/dist-packages/redisbench_admin/run/ann/pkg/ann_benchmarks/algorithms/definitions.py", line 73, in _get_definitions
with open(definition_file, "r") as f:
FileNotFoundError: [Errno 2] No such file or directory: 'algos.yaml'
adding: website-2022-03-24-22-02-58-RediSearch-RediSearch-perf-vecsim-full-run-vecsim-ann-benchmarks_FULL_16c_redisearch-hnsw_fashion-mnist-784-euclidean-allgroups-oss-cluster-03-primaries-2ecba4448c1be7fce790f7257a6974ee03fa7f4e/index.html (deflated 62%)
zip warning: name not matched: results/*
zip error: Nothing to do! (try: zip -r /tmp/results-2022-03-24-22-02-58-RediSearch-RediSearch-perf-vecsim-full-run-vecsim-ann-benchmarks_FULL_16c_redisearch-hnsw_fashion-mnist-784-euclidean-allgroups-oss-cluster-03-primaries-2ecba4448c1be7fce790f7257a6974ee03fa7f4e.zip . -i results/*)
```