### PR TITLE
Fix float conversion of vector_index_sz_mb before multiplying

### DIFF
--- a/multirun.py
+++ b/multirun.py
@@ -212,7 +212,7 @@ if __name__ == "__main__":
             index_size = -1
             if isredis:
                 if not args.cluster: # TODO: get total size from all the shards
-                    index_size = float(redis.ft('ann_benchmark').info()['vector_index_sz_mb'])*1000
+                    index_size = float(redis.ft('ann_benchmark').info()['vector_index_sz_mb'])*1024
                 f.attrs["index_size"] = index_size
             f.close()
             results_dict["build"] = {"total_clients":args.build_clients, "build_time": total_time, "vector_index_sz_mb": index_size }

--- a/multirun.py
+++ b/multirun.py
@@ -212,8 +212,8 @@ if __name__ == "__main__":
             index_size = -1
             if isredis:
                 if not args.cluster: # TODO: get total size from all the shards
-                    index_size = redis.ft('ann_benchmark').info()['vector_index_sz_mb']*1000
-                f.attrs["index_size"] = float(index_size)
+                    index_size = float(redis.ft('ann_benchmark').info()['vector_index_sz_mb'])*1000
+                f.attrs["index_size"] = index_size
             f.close()
             results_dict["build"] = {"total_clients":args.build_clients, "build_time": total_time, "vector_index_sz_mb": index_size }
 


### PR DESCRIPTION
Addresses:
```
/usr/local/lib/python3.6/dist-packages/redisbench_admin/run/ann/pkg/results/fashion-mnist-784-euclidean/10/redisearch-hnsw/build_stats
Traceback (most recent call last):
File "/usr/local/lib/python3.6/dist-packages/redisbench_admin/run/ann/pkg/multirun.py", line 216, in <module>
f.attrs["index_size"] = float(index_size)
ValueError: could not convert string to float: '194.62889099121094194.62889099121094194.62889099121094194.62889099121094194.62889099121094194.62889099121094194.62889099121094194.62889099121094194.62889099121094194.62889099121094194.62889099121094194.62889099121094194.62889099121094194.62889099121094194.62889099121094194.62889099121094194.62889099121094194.62889099121094194.62889099121094194.62889099121094194.62889099121094194.62889099121094194.62889099121094194.62889099121094194.62889099121094194.62889099121094194.62889099121094194.62889099121094194.62889099121094194.62889099121094194.62889099121094194.62889099121094194.62889099121094194.62889099121094194.62889099121094194.6(....)
```