### PR TITLE
added shards aux arg

### DIFF
--- a/ann_benchmarks/algorithms/definitions.py
+++ b/ann_benchmarks/algorithms/definitions.py
@@ -109,7 +109,7 @@ def get_run_groups(definition_file, algo = None):
 
 
 def get_definitions(definition_file, dimension, point_type="float",
-                    distance_metric="euclidean", count=10, conn_params={'host': None, 'port': None, 'auth': None, 'user': None, 'cluster': False}):
+                    distance_metric="euclidean", count=10, conn_params={'host': None, 'port': None, 'auth': None, 'user': None, 'cluster': False, 'shards': 1}):
     definitions = _get_definitions(definition_file)
 
     algorithm_definitions = {}

--- a/ann_benchmarks/algorithms/redisearch.py
+++ b/ann_benchmarks/algorithms/redisearch.py
@@ -21,7 +21,7 @@ class RediSearch(BaseANN):
         port = conn_params["port"] if conn_params["port"] else 6379
         self.redis = redis(host=host, port=port, decode_responses=False,
                            password=conn_params["auth"], username=conn_params["user"])
-        self.shards = 1
+        self.shards = conn_params["shards"]
         if conn_params['cluster']:
             self.shards = len(self.redis.get_primaries())
 

--- a/ann_benchmarks/main.py
+++ b/ann_benchmarks/main.py
@@ -172,6 +172,12 @@ def main():
         type=positive_int,
         help='specific client id (among the total clients)',
         default=1)
+    parser.add_argument(
+        '--shards',
+        type=str,
+        metavar='NUM',
+        default="1",
+        help='specify number of shards')
 
     args = parser.parse_args()
     if args.timeout == -1:
@@ -186,7 +192,7 @@ def main():
     if (args.build_only or args.test_only) and not args.local:
         raise Exception('Can\'t run build or test only on docker')
 
-    conn_params = {'host': args.host, 'port': args.port, 'auth': args.auth, 'user': args.user, 'cluster': args.cluster}
+    conn_params = {'host': args.host, 'port': args.port, 'auth': args.auth, 'user': args.user, 'cluster': args.cluster, 'shards': args.shards}
 
     if args.total_clients < args.client_id:
         raise Exception('must satisfy 1 <= client_id <= total_clients')

--- a/multirun.py
+++ b/multirun.py
@@ -135,6 +135,12 @@ if __name__ == "__main__":
         '--cluster',
         action='store_true',
         help='working with a cluster')
+    parser.add_argument(
+        '--shards',
+        type=str,
+        metavar='NUM',
+        default="1",
+        help='specify number of shards')
 
     args = parser.parse_args()
 
@@ -169,6 +175,7 @@ if __name__ == "__main__":
     if args.auth:       base += ' --auth ' + args.auth
     if args.force:      base += ' --force'
     if args.cluster:    base += ' --cluster'
+    if args.shards:     base += ' --shards' + args.shards
 
     base_build = base + ' --build-only --total-clients ' + args.build_clients
     base_test = base + ' --test-only --runs {} --total-clients {}'.format(args.runs, args.test_clients)


### PR DESCRIPTION
This PR adds the `--shards` axuilary argument for letting the algorithm know ahead of time the number of shards on clustered db. 
On RediSearch it will let the algorithm running on RS cluster without OSS cluster API to adjust the pre allocation setting on FT.CREATE