### PR TITLE
Fixed shards arg usage on multirun/redisearch

### DIFF
--- a/ann_benchmarks/algorithms/redisearch.py
+++ b/ann_benchmarks/algorithms/redisearch.py
@@ -21,7 +21,7 @@ class RediSearch(BaseANN):
         port = conn_params["port"] if conn_params["port"] else 6379
         self.redis = redis(host=host, port=port, decode_responses=False,
                            password=conn_params["auth"], username=conn_params["user"])
-        self.shards = conn_params["shards"]
+        self.shards = int(conn_params["shards"])
         if conn_params['cluster']:
             self.shards = len(self.redis.get_primaries())
 

--- a/multirun.py
+++ b/multirun.py
@@ -175,7 +175,7 @@ if __name__ == "__main__":
     if args.auth:       base += ' --auth ' + args.auth
     if args.force:      base += ' --force'
     if args.cluster:    base += ' --cluster'
-    if args.shards:     base += ' --shards' + args.shards
+    if args.shards:     base += ' --shards ' + args.shards
 
     base_build = base + ' --build-only --total-clients ' + args.build_clients
     base_test = base + ' --test-only --runs {} --total-clients {}'.format(args.runs, args.test_clients)


### PR DESCRIPTION
error 1 fix

```
run.py: error: unrecognized arguments: --shards3
```
error 2 is related to str/int division 