### PR TITLE
Fixed algorithm str when using FLAT on redisearch

### DIFF
--- a/ann_benchmarks/algorithms/redisearch.py
+++ b/ann_benchmarks/algorithms/redisearch.py
@@ -15,6 +15,7 @@ class RediSearch(BaseANN):
         self.name = 'redisearch-%s (%s)' % (self.algo, self.method_param)
         self.index_name = "ann_benchmark"
         self.text = None
+        self.ef = None
         
         redis = RedisCluster if conn_params['cluster'] else Redis
         host = conn_params["host"] if conn_params["host"] else 'localhost'
@@ -87,4 +88,7 @@ class RediSearch(BaseANN):
         self.redis.execute_command("FLUSHALL")
 
     def __str__(self):
-        return self.name + f", efRuntime: {self.ef}"
+        res = self.name
+        if self.ef is not None:
+            res += + f", efRuntime: {self.ef}"
+        return res


### PR DESCRIPTION
Error to fix:
```
got a train set of size (1000000 * 960)
got 1000 queries
running 31 out of them
Running query argument group 1 of 1...
Run 1/1...
qps: 0.5204312185441995
Traceback (most recent call last):
  File "/home/ubuntu/ann-benchmarks/run.py", line 12, in <module>
    main()
  File "/home/ubuntu/ann-benchmarks/ann_benchmarks/main.py", line 316, in main
    run_worker(1, args, queue)
  File "/home/ubuntu/ann-benchmarks/ann_benchmarks/main.py", line 41, in run_worker
    run(definition, args.dataset, args.count, args.runs, args.batch,
  File "/home/ubuntu/ann-benchmarks/ann_benchmarks/runner.py", line 178, in run
    descriptor, results = run_individual_query(
  File "/home/ubuntu/ann-benchmarks/ann_benchmarks/runner.py", line 94, in run_individual_query
    "name": str(algo),
  File "/home/ubuntu/ann-benchmarks/ann_benchmarks/algorithms/redisearch.py", line 90, in __str__
    return self.name + f", efRuntime: {self.ef}"
AttributeError: 'RediSearch' object has no attribute 'ef'

```
