### PR TITLE
Ensure all primaries receive the FT.CREATE due to 'missing index error on querying' in multi-node scenarios

### DIFF
--- a/ann_benchmarks/algorithms/redisearch.py
+++ b/ann_benchmarks/algorithms/redisearch.py
@@ -37,7 +37,7 @@ class RediSearch(BaseANN):
             elif self.algo == "FLAT":
                 args.extend(['vector', 'VECTOR', self.algo, '6', 'TYPE', 'FLOAT32', 'DIM', len(X[0]), 'DISTANCE_METRIC', self.metric])
             print("Calling FT.CREATE", *args)
-            self.redis.execute_command('FT.CREATE', *args,  target_nodes='random')
+            self.redis.execute_command('FT.CREATE', *args,  target_nodes='primaries')
         except Exception as e:
             if 'Index already exists' not in str(e):
                 raise


### PR DESCRIPTION
Fixes for errors like the above on multi-node scenarios
```
  File "/home/ubuntu/ann-benchmarks/ann_benchmarks/runner.py", line 77, in <listcomp>
    descriptor, results = run_individual_query(
  File "/home/ubuntu/ann-benchmarks/ann_benchmarks/runner.py", line 77, in run_individual_query
    results = [single_query(x) for x in X_test]
  File "/home/ubuntu/ann-benchmarks/ann_benchmarks/runner.py", line 46, in single_query
    results = [single_query(x) for x in X_test]
    candidates = algo.query(v, count)
  File "/home/ubuntu/ann-benchmarks/ann_benchmarks/runner.py", line 77, in <listcomp>
  File "/home/ubuntu/ann-benchmarks/ann_benchmarks/algorithms/redisearch.py", line 85, in query
    results = [single_query(x) for x in X_test]
  File "/home/ubuntu/ann-benchmarks/ann_benchmarks/runner.py", line 46, in single_query
    return [int(doc) for doc in self.redis.execute_command(*q, target_nodes='random')[1:]]
  File "/usr/local/lib/python3.10/dist-packages/redis/cluster.py", line 1090, in execute_command
    candidates = algo.query(v, count)
  File "/home/ubuntu/ann-benchmarks/ann_benchmarks/algorithms/redisearch.py", line 85, in query
    return [int(doc) for doc in self.redis.execute_command(*q, target_nodes='random')[1:]]
  File "/usr/local/lib/python3.10/dist-packages/redis/cluster.py", line 1090, in execute_command
    raise e
  File "/usr/local/lib/python3.10/dist-packages/redis/cluster.py", line 1076, in execute_command
    raise e
  File "/usr/local/lib/python3.10/dist-packages/redis/cluster.py", line 1076, in execute_command
    res[node.name] = self._execute_command(node, *args, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/redis/cluster.py", line 1126, in _execute_command
    res[node.name] = self._execute_command(node, *args, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/redis/cluster.py", line 1126, in _execute_command
    response = redis_node.parse_response(connection, command, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/redis/client.py", line 1286, in parse_response
    response = redis_node.parse_response(connection, command, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/redis/client.py", line 1286, in parse_response
    response = connection.read_response()
  File "/usr/local/lib/python3.10/dist-packages/redis/connection.py", line 897, in read_response
    response = connection.read_response()
  File "/usr/local/lib/python3.10/dist-packages/redis/connection.py", line 897, in read_response
    raise response
redis.exceptions.ResponseError: ann_benchmark: no such index
    raise response
redis.exceptions.ResponseError: ann_benchmark: no such index
total test time: 57.677470684051514

```